### PR TITLE
Padfile validation, validation context control

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,9 +1,7 @@
 name: benchmark
 
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.1.0 - 2025-07-25
+
+Preparing to swap in for sciop, where it will get real field testing.
+Basic creation and validation systems work and have been validated against a corpus of
+torrents in the wild.
+
+Changelog will now actually contain meaningful changes, since the package is now considered
+out of experimental phase and in beta.
+
 ## v0.0.2 - 2025-05-24
 
 - Bugfix: force absolute paths in path_roots

--- a/docs/index.md
+++ b/docs/index.md
@@ -175,6 +175,7 @@ The reasons we did not use these other tools and wrote this one:
 
 usage/torrent
 usage/cli
+usage/validation
 ```
 
 ```{toctree}

--- a/docs/usage/validation.md
+++ b/docs/usage/validation.md
@@ -1,0 +1,27 @@
+# Validation
+
+## Strict mode
+
+By default, `torrent-models` attempts to treat torrent files as an open format,
+allowing extra attributes, and only enforcing correctness according to existing BEP specifications
+necessary for the torrent to work.
+
+Various parts of the validation process can be made more strict by using pydantic's
+[strict mode](https://docs.pydantic.dev/latest/concepts/strict_mode),
+either passing `strict=True` to {method}`~pydantic.BaseModel.model_validate`,
+or annotating the model with `Annotated[Torrent, pydantic.Strict()]`.
+
+- If padfiles are present, all files must be padded to piece boundaries
+  (the `strict` mode for `padding` in validation context, below)
+- Padfiles must be named such that their path is `.pad/{size}`.
+- (raise an issue if you want more strict behavior!)
+
+## Control via Validation Context
+
+The behavior of validation can be modified using pydantic's
+[validation context](https://docs.pydantic.dev/latest/concepts/validators/#validation-context).
+
+```{eval-rst}
+.. autoclass:: torrent_models.types.validation.ValidationContext
+    :members:
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ ignore = [
 fixable = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
+"scripts/validate_corpus.py" = ["T10"]
 "src/torrent_models/__init__.py" = [
     # Import order matters for top level __init__.py
     "I001"

--- a/scripts/validate_corpus.py
+++ b/scripts/validate_corpus.py
@@ -1,0 +1,67 @@
+"""
+Roundtrip a directory of valid torrents to ensure that we correctly read, validate, and write them.
+"""
+
+import argparse
+from pathlib import Path
+
+import bencode_rs
+from _pytest.assertion.util import _compare_eq_dict
+from tqdm import tqdm
+
+from torrent_models import Torrent
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--directory")
+    parser.add_argument("-s", "--start", default=0, type=int)
+    args = parser.parse_args()
+    return args
+
+
+def files_equal(file1: Path, file2: Path) -> bool:
+    data1 = file1.read_bytes()
+    data2 = file2.read_bytes()
+    if data1 != data2:
+        decoded_1 = bencode_rs.bdecode(data1)
+        decoded_2 = bencode_rs.bdecode(data2)
+        # some torrent creators flatten length-1 lists, others don't - either is fine.
+        if (
+            (url_list := decoded_1.get(b"url-list"))
+            and isinstance(url_list, list)
+            and len(url_list) == 1
+        ):
+            decoded_1[b"url-list"] = url_list[0]
+        diff = _compare_eq_dict(decoded_1, decoded_2, lambda x: x, verbose=1)
+        if len(diff) > 1:
+            breakpoint()
+
+
+def roundtrip_torrent(path: Path, output_dir: Path):
+    output_path = output_dir / path.name
+    try:
+        t = Torrent.read(path, context={"padding": "ignore"})
+        t.write(output_path)
+    except Exception as e:
+        e = e
+        breakpoint()
+    files_equal(path, output_dir / path.name)
+    output_path.unlink()
+
+
+def main():
+    args = parse_args()
+    tmp_dir = Path().cwd() / "__tmp__"
+    tmp_dir.mkdir(exist_ok=True)
+    torrent_dir = Path(args.directory)
+    torrents = sorted(list(torrent_dir.rglob("*.torrent")))
+    for torrent in tqdm(torrents[args.start :]):
+        try:
+            roundtrip_torrent(torrent, tmp_dir)
+        except Exception as e:
+            raise ValueError(f"{torrent} is invalid") from e
+
+
+if __name__ == "__main__":
+    main()

--- a/src/torrent_models/create.py
+++ b/src/torrent_models/create.py
@@ -14,13 +14,19 @@ from pydantic import AnyUrl, Field, model_validator
 
 from torrent_models import Torrent, TorrentVersion
 from torrent_models.compat import get_size
-from torrent_models.const import EXCLUDE_FILES
+from torrent_models.const import DEFAULT_TORRENT_CREATOR, EXCLUDE_FILES
 from torrent_models.hashing import HybridHasher, V1Hasher, add_padfiles
 from torrent_models.hashing.v1 import sort_v1
 from torrent_models.info import InfoDictHybrid, InfoDictHybridCreate, InfoDictV1, InfoDictV2
 from torrent_models.torrent import TorrentBase
-from torrent_models.types import AbsPath, FileItem, TrackerFields, V1PieceLength, V2PieceLength
-from torrent_models.types.serdes import ByteUrl
+from torrent_models.types import (
+    AbsPath,
+    ByteStr,
+    FileItem,
+    TrackerFields,
+    V1PieceLength,
+    V2PieceLength,
+)
 from torrent_models.types.v2 import FileTree, PieceLayers
 
 
@@ -48,7 +54,8 @@ class TorrentCreate(TorrentBase):
     """
 
     # make parent types optional
-    announce: ByteUrl | None = None  # type: ignore
+    announce: ByteStr | None = None  # type: ignore
+    created_by: ByteStr | None = Field(DEFAULT_TORRENT_CREATOR, alias="created by")
 
     # convenience fields
     info: InfoDictHybridCreate = Field(default_factory=InfoDictHybridCreate)  # type: ignore
@@ -66,7 +73,7 @@ class TorrentCreate(TorrentBase):
         default_factory=Path, description="Path to interpret paths relative to"
     )
 
-    trackers: list[ByteUrl] | list[list[ByteUrl]] | None = Field(
+    trackers: list[ByteStr] | list[list[ByteStr]] | None = Field(
         None,
         description="Convenience method for declaring tracker lists."
         "If a flat list, put each tracker in a separate tier."

--- a/src/torrent_models/create.py
+++ b/src/torrent_models/create.py
@@ -10,7 +10,7 @@ import multiprocessing as mp
 from pathlib import Path
 from typing import Any, Self, cast
 
-from pydantic import AnyUrl, Field, model_validator
+from pydantic import Field, model_validator
 
 from torrent_models import Torrent, TorrentVersion
 from torrent_models.compat import get_size
@@ -54,7 +54,7 @@ class TorrentCreate(TorrentBase):
     """
 
     # make parent types optional
-    announce: ByteStr | None = None  # type: ignore
+    announce: ByteStr | None = None
     created_by: ByteStr | None = Field(DEFAULT_TORRENT_CREATOR, alias="created by")
 
     # convenience fields
@@ -322,13 +322,13 @@ class TorrentCreate(TorrentBase):
         if self.trackers:
             if isinstance(self.trackers[0], list):
 
-                self.trackers = cast(list[list[AnyUrl]], self.trackers)
+                self.trackers = cast(list[list[str]], self.trackers)
                 if len(self.trackers[0]) == 1 and len(self.trackers[0][0]) == 1:
                     return {"announce": self.trackers[0][0]}
                 else:
                     return {"announce": self.trackers[0][0], "announce-list": self.trackers}
             else:
-                self.trackers = cast(list[AnyUrl], self.trackers)
+                self.trackers = cast(list[str], self.trackers)
                 if len(self.trackers) == 1:
                     return {"announce": self.trackers[0]}
                 else:

--- a/src/torrent_models/info.py
+++ b/src/torrent_models/info.py
@@ -38,7 +38,7 @@ class InfoDictRoot(ConfiguredBase):
         decode to strings first
         """
         if isinstance(data, dict) and any([isinstance(k, bytes) for k in data]):
-            data = str_keys(data)  # type: ignore
+            data = str_keys(data)
         return data
 
 
@@ -69,7 +69,7 @@ class InfoDictV1Base(InfoDictRoot):
 
                 self._total_length = total
             else:
-                self._total_length = self.length
+                self._total_length = cast(int, self.length)
         return self._total_length
 
     @model_validator(mode="after")

--- a/src/torrent_models/info.py
+++ b/src/torrent_models/info.py
@@ -320,11 +320,20 @@ class InfoDictHybrid(InfoDictV2, InfoDictV1):
         ), "v1 file lists and v2 file trees must have same length"
         for v1_file, v2_item in zip(v1_files, v2_files.items()):
             v2_path, v2_file = v2_item
+            v1_posix = posixjoin(*v1_file.path)
 
-            assert posixjoin(*v1_file.path) == v2_path, (
+            assert v1_posix == v2_path, (
                 "v1 file lists and v2 file trees must be in the same order "
-                "and have matching path names, excluding v1 padfiles"
+                "and have matching path names, excluding v1 padfiles. "
+                f"Got:\n"
+                f"v1 path: {posixjoin(*v1_file.path)}\n"
+                f"v2 path: {v2_path}\n"
             )
-            assert v1_file.length == v2_file["length"], "v1 and v2 file lengths must match"
+            assert v1_file.length == v2_file["length"], (
+                "v1 and v2 file lengths must match. Got: \n"
+                f"path: {v1_posix}\n"
+                f"v1 length: {v1_file.length}\n"
+                f"v2 length: {v2_file['length']}"
+            )
 
         return self

--- a/src/torrent_models/torrent.py
+++ b/src/torrent_models/torrent.py
@@ -15,6 +15,7 @@ from torrent_models.base import ConfiguredBase
 from torrent_models.const import DEFAULT_TORRENT_CREATOR
 from torrent_models.info import (
     InfoDictHybrid,
+    InfodictUnionType,
     InfoDictV1,
     InfoDictV1Base,
     InfoDictV2,
@@ -40,7 +41,7 @@ class TorrentBase(ConfiguredBase):
     comment: ByteStr | None = None
     created_by: ByteStr | None = Field(DEFAULT_TORRENT_CREATOR, alias="created by")
     creation_date: UnixDatetime | None = Field(default=None, alias="creation date")
-    info: InfoDictV1 | InfoDictV2 | InfoDictHybrid = Field(..., union_mode="left_to_right")
+    info: InfodictUnionType
     piece_layers: PieceLayersType | None = Field(None, alias="piece layers")
     url_list: ListOrValue[ByteUrl] | None = Field(
         None, alias="url-list", description="List of webseeds"

--- a/src/torrent_models/torrent.py
+++ b/src/torrent_models/torrent.py
@@ -22,7 +22,6 @@ from torrent_models.info import (
 )
 from torrent_models.types import (
     ByteStr,
-    ByteUrl,
     FileItem,
     FileTreeItem,
     ListOrValue,
@@ -47,7 +46,7 @@ class TorrentBase(ConfiguredBase):
     )
 
     @property
-    def webseeds(self) -> list[ByteUrl] | None:
+    def webseeds(self) -> list[str] | None:
         """alias to url_list"""
         return self.url_list
 

--- a/src/torrent_models/torrent.py
+++ b/src/torrent_models/torrent.py
@@ -1,6 +1,6 @@
 from math import ceil
 from pathlib import Path
-from typing import Any, Self, cast
+from typing import Any, BinaryIO, Self, cast
 from typing import Literal as L
 
 import bencode_rs
@@ -52,11 +52,16 @@ class TorrentBase(ConfiguredBase):
         return self.url_list
 
     @classmethod
-    def read(cls, path: Path | str) -> Self:
-        with open(path, "rb") as tfile:
-            tdata = tfile.read()
+    def read_stream(cls, stream: BinaryIO) -> Self:
+        tdata = stream.read()
         tdict = bencode_rs.bdecode(tdata)
         return cls.from_decoded(decoded=tdict)
+
+    @classmethod
+    def read(cls, path: Path | str) -> Self:
+        with open(path, "rb") as tfile:
+            torrent = cls.read_stream(tfile)
+        return torrent
 
     @classmethod
     def from_decoded(cls, decoded: dict[str | bytes, Any], **data: Any) -> Self:

--- a/src/torrent_models/types/serdes.py
+++ b/src/torrent_models/types/serdes.py
@@ -116,9 +116,7 @@ def _from_list(
     val: list[_Inner] | None, handler: SerializerFunctionWrapHandler
 ) -> list[_Inner] | _Inner | None:
     partial = handler(val)
-    if not partial:
-        return None
-    elif len(partial) == 1:
+    if partial and len(partial) == 1:
         return partial[0]
     else:
         return partial

--- a/src/torrent_models/types/v1.py
+++ b/src/torrent_models/types/v1.py
@@ -4,10 +4,9 @@ Types used only in v1 (and hybrid) torrents
 
 from typing import Annotated, Self
 
-from annotated_types import Gt
+from annotated_types import Ge
 from pydantic import (
     AfterValidator,
-    BaseModel,
     BeforeValidator,
     PlainSerializer,
     ValidationInfo,
@@ -15,6 +14,7 @@ from pydantic import (
 )
 from pydantic_core.core_schema import SerializationInfo
 
+from torrent_models.base import ConfiguredBase
 from torrent_models.types.common import FilePart, SHA1Hash, _power_of_two
 
 V1PieceLength = Annotated[int, AfterValidator(_power_of_two)]
@@ -49,8 +49,8 @@ Pieces = Annotated[
 ]
 
 
-class FileItem(BaseModel):
-    length: Annotated[int, Gt(0)]
+class FileItem(ConfiguredBase):
+    length: Annotated[int, Ge(0)]
     path: list[FilePart]
     attr: bytes | None = None
     """

--- a/src/torrent_models/types/v2.py
+++ b/src/torrent_models/types/v2.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from math import ceil
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, NotRequired, TypeAlias, Union, cast
+from typing import TYPE_CHECKING, Annotated, Any, NotRequired, TypeAlias, cast
 from typing import Literal as L
 
 from pydantic import AfterValidator, BaseModel, PlainSerializer
@@ -64,12 +64,10 @@ PieceLayersType = dict[SHA256Hash, PieceLayerItem]
 FileTreeItem = TypedDict(
     "FileTreeItem", {"length": int, "pieces root": NotRequired[PieceLayerItem]}
 )
-FileTreeType: TypeAlias = Annotated[
-    TypeAliasType(  # type: ignore
-        "FileTreeType", dict[bytes, Union[dict[L[""], FileTreeItem], "FileTreeType"]]  # type: ignore
-    ),
-    AfterValidator(_sort_keys),
-]
+_FileTreeType = TypeAliasType(
+    "_FileTreeType", 'dict[bytes, dict[L[""], FileTreeItem] | _FileTreeType]'
+)
+FileTreeType: TypeAlias = Annotated[_FileTreeType, AfterValidator(_sort_keys)]
 
 
 class MerkleTree(BaseModel):

--- a/src/torrent_models/types/validation.py
+++ b/src/torrent_models/types/validation.py
@@ -1,0 +1,66 @@
+from typing import Literal, TypedDict
+
+
+class ValidationContext(TypedDict, total=False):
+    """
+    Validation Context parameters that affect validation behavior
+
+    Validation behavior can be controlled like this:
+
+    ```python
+    Torrent.model_validate(data, context={"padding": "default"})
+    ```
+
+    with any of the values described in this typed dict.
+
+    This model is primarily used for documentation,
+    because there is not a valid way that i am aware of to annotate the ValidationInfo.context
+    dict since it is read-only (so cast can't be used),
+    and one can't annotate non-self attributes.
+    plz PR if you know how to get mypy to validate with this type.
+
+    References:
+        https://docs.pydantic.dev/latest/concepts/validators/#validation-context
+    """
+
+    padding: Literal["default", "ignore", "strict", "forbid"]
+    """
+    Control how padfiles are validated
+    
+    `'default`': v1-only torrents are validated by confirming individual files + pads
+             are a multiple of the piece size. Hybrid torrents are validated
+             as if `'strict'` had been passed.
+    `'ignore'`: skip all padfile validation.
+    `'strict'`: every file must start at a piece boundary.
+    `'forbid'`: no padfiles may be present.
+
+    if we are validating in pydantic's `strict` mode,
+    - `'ignore'` is ignored: strict means that the torrent must be as correct as it can be
+    - `'strict'` is unchanged, and becomes the default
+    - `'forbid'` is unchanged for v1-only: it's strictly valid to forbid padfiles,
+      but for hybrid torrents becomes an error: hybrid torrents *must* be padded
+      and the padding must be correct.
+    """
+    padding_path: Literal["default", "strict"]
+    """
+    BEP0047 recommends that padfiles are named `.pad/{length}`:
+    
+    > While clients implementing this extensions will have no use for the path of a padding file 
+    > it should be included for backwards compatibility since it is a mandatory field in BEP 3.
+    > The recommended path is [".pad", "N"] where N is the length of the padding file in base10. 
+    > This way clients not aware of this extension will write the padding files 
+    > into a single directory, 
+    > potentially re-using padding files from other torrents also stored in that directory.
+    
+    However this is not required, and is often violated. 
+    BEP0047 also recommends now requiring `path` at all for padfiles:
+    
+    > To eventually allow the path field to be omitted clients implementing this BEP 
+    > should not require it to be present on padding files.
+    
+    So the default behavior is to not check the padfile names,
+    but passing `strict` here validates they are `[".pad", length]`
+    
+    References:
+        https://www.bittorrent.org/beps/bep_0047.html
+    """

--- a/src/torrent_models/types/validation.py
+++ b/src/torrent_models/types/validation.py
@@ -27,9 +27,8 @@ class ValidationContext(TypedDict, total=False):
     """
     Control how padfiles are validated
     
-    `'default`': v1-only torrents are validated by confirming individual files + pads
-             are a multiple of the piece size. Hybrid torrents are validated
-             as if `'strict'` had been passed.
+    `'default`': v1-only torrents -> ignore
+                 Hybrid torrents -> strict
     `'ignore'`: skip all padfile validation.
     `'strict'`: every file must start at a piece boundary.
     `'forbid'`: no padfiles may be present.

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -86,4 +86,4 @@ def test_create_libtorrent(libtorrent_pair, tmp_path_factory):
     :return:
     """
     lt, generated = libtorrent_pair
-    assert lt == generated.model_dump_torrent()
+    assert lt == generated.model_dump_torrent(mode="binary")

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,0 +1,36 @@
+import pytest
+from pydantic import TypeAdapter
+
+from torrent_models import KiB
+from torrent_models.info import InfoDictHybrid, InfodictUnionType, InfoDictV1, InfoDictV2
+from torrent_models.types import str_keys
+
+v1_infodict = {
+    b"name": b"sup.exe",
+    b"pieces": b"0" * 20,
+    b"piece length": 16 * KiB,
+    b"length": 16 * KiB,
+}
+v2_infodict = {
+    b"name": b"sup.exe",
+    b"meta version": 2,
+    b"piece length": 16 * KiB,
+    b"file tree": {b"sup.exe": {b"": {b"length": 16 * KiB, b"pieces root": b"0" * 40}}},
+}
+hybrid_infodict = {**v1_infodict, **v2_infodict}
+infodicts = {"v1": v1_infodict, "v2": v2_infodict, "hybrid": hybrid_infodict}
+models = {"v1": InfoDictV1, "v2": InfoDictV2, "hybrid": InfoDictHybrid}
+
+
+@pytest.mark.parametrize("version", ("v1", "v2", "hybrid"))
+@pytest.mark.parametrize("mode", ("bytes", "str", "model"))
+def test_infodict_union_discriminator(version, mode):
+    info = infodicts[version].copy()
+    if mode == "str":
+        info = str_keys(info)
+    elif mode == "model":
+        info = models[version].model_validate(info)
+
+    adapter = TypeAdapter(InfodictUnionType)
+    v = adapter.validate_python(info)
+    assert isinstance(v, models[version])

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,60 @@
+import pytest
+from pydantic_core._pydantic_core import ValidationError
+
+from torrent_models.const import KiB
+from torrent_models.info import InfoDictV1Base
+from torrent_models.types import FileItem
+
+no_padding = [
+    FileItem(path=["no_padding"], length=14 * KiB),
+    FileItem(path=["sup"], length=7 * KiB),
+]
+correct_padding = [
+    FileItem(path=["correct"], length=16 * KiB),
+    FileItem(path=["hey"], length=14 * KiB),
+    FileItem(path=[".pad", str(2 * KiB)], length=2 * KiB, attr=b"p"),
+    FileItem(path=["sup"], length=3 * KiB),
+    FileItem(path=[".pad", str(13 * KiB)], length=13 * KiB, attr=b"p"),
+]
+inconsistent_padding = [
+    FileItem(path=["inconsistent"], length=5 * KiB),
+    FileItem(path=["hey"], length=14 * KiB),
+    FileItem(path=[".pad", str(2 * KiB)], length=2 * KiB, attr=b"p"),
+    FileItem(path=["sup"], length=3 * KiB),
+    FileItem(path=[".pad", str(13 * KiB)], length=13 * KiB, attr=b"p"),
+]
+incorrect_padding = [
+    FileItem(path=["incorrect"], length=16 * KiB),
+    FileItem(path=["hey"], length=14 * KiB),
+    FileItem(path=[".pad", str(7 * KiB)], length=7 * KiB, attr=b"p"),
+    FileItem(path=["sup"], length=14 * KiB),
+    FileItem(path=[".pad", str(7 * KiB)], length=7 * KiB, attr=b"p"),
+]
+
+
+padding_cases = (no_padding, correct_padding, inconsistent_padding, incorrect_padding)
+
+
+@pytest.mark.parametrize(
+    "mode,valid",
+    [
+        ("default", (True, True, True, False)),
+        ("strict", (False, True, False, False)),
+        ("forbid", (True, False, False, False)),
+        ("ignore", (True, True, True, True)),
+    ],
+)
+def test_padding_validation(mode, valid):
+    """
+    See description of padding modes in ValidationContext typed dict
+    """
+    for case, is_valid in zip(padding_cases, valid):
+        if is_valid:
+            InfoDictV1Base.model_validate(
+                dict(name="test", files=case, piece_length=16 * KiB), context={"padding": mode}
+            )
+        else:
+            with pytest.raises(ValidationError):
+                InfoDictV1Base.model_validate(
+                    dict(name="test", files=case, piece_length=16 * KiB), context={"padding": mode}
+                )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -38,7 +38,7 @@ padding_cases = (no_padding, correct_padding, inconsistent_padding, incorrect_pa
 @pytest.mark.parametrize(
     "mode,valid",
     [
-        ("default", (True, True, True, False)),
+        ("default", (True, True, True, True)),
         ("strict", (False, True, False, False)),
         ("forbid", (True, False, False, False)),
         ("ignore", (True, True, True, True)),


### PR DESCRIPTION
in re: some shrimptools-created torrents that had some odd file structure to them, added some validation for some basic padfile structure. not tested against natural torrent corpus yet, so might be too strict by default, but prepping for moving into sciop

<!-- readthedocs-preview torrent-models start -->
----
📚 Documentation preview 📚: https://torrent-models--5.org.readthedocs.build/en/5/

<!-- readthedocs-preview torrent-models end -->